### PR TITLE
fix: remove hardcoded AWS profile from provider configuration

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -12,8 +12,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.aws_region
-  profile = "liatrio-forge"
+  region = var.aws_region
 
   default_tags {
     tags = {


### PR DESCRIPTION
Remove 'profile = "liatrio-forge"' from provider.tf to allow GitHub Actions to use credentials from environment variables (AWS_ACCESS_KEY_ID/SECRET).

Local development still works via AWS default credential chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS provider configuration by removing the profile specification, allowing default AWS credential resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->